### PR TITLE
Add increased memory limit entitlement.

### DIFF
--- a/SwiftChat/SwiftChat.entitlements
+++ b/SwiftChat/SwiftChat.entitlements
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.developer.kernel.increased-memory-limit</key>
+	<true/>
+</dict>
 </plist>


### PR DESCRIPTION
Large language models are... well... large! Some iPhones and iPads can access more RAM, so lets enable it.

more reading:
https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_kernel_increased-memory-limit

there is also extended virtual address space, but I am unsure if it is related.