### PR TITLE
Moving imported file types to Info.plist

### DIFF
--- a/SwiftChat.xcodeproj/project.pbxproj
+++ b/SwiftChat.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		6A7344A52B6AECA500990D7B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		EB545ED72A0AC32A00C8A5BD /* StatusView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusView.swift; sourceTree = "<group>"; };
 		EB90085C2A02C53100B321C4 /* ControlView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ControlView.swift; sourceTree = "<group>"; };
 		EB9008682A0578C300B321C4 /* ModelLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelLoader.swift; sourceTree = "<group>"; };
@@ -107,6 +108,7 @@
 		EBE1152D2A02AECC000A0CF4 /* SwiftChat */ = {
 			isa = PBXGroup;
 			children = (
+				6A7344A52B6AECA500990D7B /* Info.plist */,
 				EBE1152E2A02AECC000A0CF4 /* SwiftChatApp.swift */,
 				EB90085C2A02C53100B321C4 /* ControlView.swift */,
 				EBE115302A02AECC000A0CF4 /* ContentView.swift */,
@@ -452,6 +454,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SwiftChat/Info.plist;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -489,6 +492,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SwiftChat/Info.plist;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/SwiftChat/ControlView.swift
+++ b/SwiftChat/ControlView.swift
@@ -160,6 +160,6 @@ struct ControlView: View {
 }
 
 private extension UTType {
-    static let mlpackage = UTType(filenameExtension: "mlpackage", conformingTo: .item)!
-    static let mlmodelc = UTType(filenameExtension: "mlmodelc", conformingTo: .item)!
+    static let mlpackage = UTType(importedAs: "com.huggingface.mlpackage")
+    static let mlmodelc = UTType(importedAs: "com.huggingface.mlmodelc")
 }

--- a/SwiftChat/Info.plist
+++ b/SwiftChat/Info.plist
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>MLPackage File</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.huggingface.mlpackage</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>MLModelc File</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.huggingface.mlmodelc</string>
+			</array>
+		</dict>
+	</array>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>item</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>MLPackage File</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>com.huggingface.mlpackage</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>mlpackage</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>item</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>MLModellc File</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>com.huggingface.mlmodelc</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>mlmodelc</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
While running the demo on my Mac (os is 13.2.1), I was unable to select the .mlpackage file to some issues with the defined UTType's

Moving them to the app-level `Info.plist` seems to have fixed any import issues

Let me know if you find any issues with this solution while testing across different devices! 